### PR TITLE
Fix: Correctly identify and save final work products

### DIFF
--- a/services/agentset/src/AgentSet.ts
+++ b/services/agentset/src/AgentSet.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { Agent } from './agents/Agent';
-import { MapSerializer, BaseEntity, createAuthenticatedAxios, PluginParameterType } from '@cktmcs/shared';
+import { MapSerializer, BaseEntity, createAuthenticatedAxios, PluginParameterType, OutputType } from '@cktmcs/shared';
 import { v4 as uuidv4 } from 'uuid';
 import { AgentSetStatistics, InputValue } from '@cktmcs/shared';
 import { AgentPersistenceManager } from './utils/AgentPersistenceManager';
@@ -1075,11 +1075,12 @@ export class AgentSet extends BaseEntity {
                     }
                 }
             }
+            const allStepsForMission = Array.from(globalStepMap.values()).map(entry => entry.step);
             for (const agent of this.agents.values()) {
                 if (agent.getMissionId() === missionId) {
                     const status = agent.getStatus();
                     // Pass the globalStepMap to getStatistics
-                    const agentStats = await agent.getStatistics(globalStepMap);
+                    const agentStats = await agent.getStatistics(globalStepMap, allStepsForMission);
                     if (!stats.agentsByStatus.has(status)) {
                         stats.agentsByStatus.set(status, [agentStats]);
                     } else {

--- a/services/agentset/src/agents/Step.ts
+++ b/services/agentset/src/agents/Step.ts
@@ -7,7 +7,8 @@ import { PluginParameterType,
     ActionVerbTask,
     ExecutionContext as PlanExecutionContext,
     PlanTemplate,
-    MissionFile } from '@cktmcs/shared'; // Added ActionVerbTask and MissionFile
+    MissionFile,
+    OutputType } from '@cktmcs/shared'; // Added ActionVerbTask, MissionFile, and OutputType
 import { MapSerializer } from '@cktmcs/shared';
 import { MessageType } from '@cktmcs/shared'; // Ensured MessageType is here, assuming it's separate or also from shared index
 import { AgentPersistenceManager } from '../utils/AgentPersistenceManager';
@@ -161,6 +162,19 @@ export class Step {
             s.dependencies.some(dep => dep.sourceStepId === this.id)
         );
         return dependents.length === 0;
+    }
+
+    getOutputType(allSteps: Step[]): OutputType {
+        // If the step generates a plan, its output type is PLAN
+        if (this.result?.some(r => r.resultType === PluginParameterType.PLAN)) {
+            return OutputType.PLAN;
+        }
+        // If the step is an endpoint and doesn't generate a plan, its output type is FINAL
+        if (this.isEndpoint(allSteps)) {
+            return OutputType.FINAL;
+        }
+        // Otherwise, its output type is INTERIM
+        return OutputType.INTERIM;
     }
 
     private async handleForeach(): Promise<PluginOutput[]> {

--- a/shared/src/types/Agent.ts
+++ b/shared/src/types/Agent.ts
@@ -21,3 +21,9 @@ export interface AgentConfig {
     role?: string;
     roleCustomizations?: any;
 }
+
+export enum OutputType {
+    INTERIM = 'interim',
+    FINAL = 'final',
+    PLAN = 'plan',
+}


### PR DESCRIPTION
Introduced a new 'Plan' output type to correctly flag steps that are replaced by a plan. Fixed an issue where final work products were not being saved to the shared file space by ensuring that work products are uploaded only when they are final for the agent that produced them.